### PR TITLE
Fix gs Makefile components path issue

### DIFF
--- a/gs/Makefile
+++ b/gs/Makefile
@@ -14,8 +14,8 @@ SRCS := src/main.cpp \
 	src/imgui/imgui_draw.cpp \
 	src/imgui/imgui.cpp \
 	src/imgui/misc/freetype/imgui_freetype.cpp \
-	components/common/crc.cpp \
-	components/common/fec.cpp \
+	../components/common/crc.cpp \
+	../components/common/fec.cpp \
 	src/fmt/format.cc \
 	src/fmt/os.cc \
 
@@ -51,7 +51,7 @@ TAR := tar
 INCLUDE  := -Isrc \
 	-Isrc/utils \
 	-Isrc/imgui \
-	-Icomponents/common \
+	-I../components/common \
 	-I/opt/vc/include/ \
 	-I/usr/include/freetype2
 


### PR DESCRIPTION
gs can be compiled on Raspberry Pi 3B+

- Makefile with specific dir, which is NOT avaliable #17 