### PR TITLE
Fix typo in gs Makefile for Raspberry Pi check

### DIFF
--- a/gs/Makefile
+++ b/gs/Makefile
@@ -72,7 +72,7 @@ CXXFLAGS := -std=c++17
 # C/C++ flags
 is_pi = 
 ifeq ($(shell arch), aarch64)
-	is_pi = yesl
+	is_pi = yes
 endif
 ifeq ($(shell arch), armv7l)
 	is_pi = yes


### PR DESCRIPTION
Not much to be said, I think there was a simple typo in GS soft Makefile.